### PR TITLE
Remove aws_iam_role from production terraform

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -19,15 +19,6 @@ locals {
   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
-
-data "aws_iam_role" "ec2_container_service_role" {
-  name = "ecsServiceRole"
-}
-
-data "aws_iam_role" "ecs_task_execution_role" {
-  name = "ecsTaskExecutionRole"
-}
-
 terraform {
   backend "s3" {
     bucket  = "terraform-state-production-apis"


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*
The [terraform apply job](https://app.circleci.com/pipelines/github/LBHackney-IT/electoral-register-resident-information-api/15/workflows/c947dd1b-fe1e-423b-af6b-a6a2eb222db2/jobs/59/parallel-runs/0/steps/0-104) for production failed with errors of: `NoSuchEntity: The role with name ecsServiceRole cannot be found.` & `NoSuchEntity: The role with name ecsTaskExecutionRole cannot be found.`

After comparing with other production terraform files, realised that these files did not make mention of  `ecsServiceRole` or `ecsTaskExecutionRole`. So have deleted these from the production terraform file only.
 
### *Follow up actions after merging PR*
* Make sure terraform and lambda deployment to production works.
