### PR TITLE
Get by ID endpoint

### DIFF
--- a/ElectoralRegisterResidentInformationApi.Tests/V1/E2ETests/E2ETest.cs
+++ b/ElectoralRegisterResidentInformationApi.Tests/V1/E2ETests/E2ETest.cs
@@ -1,8 +1,83 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using AutoFixture;
+using ElectoralRegisterResidentInformationApi.V1.Boundary.Response;
+using ElectoralRegisterResidentInformationApi.V1.Infrastructure;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
 namespace ElectoralRegisterResidentInformationApi.Tests.V1.E2ETests
 {
-    //For guidance on writing integration tests see the wiki page https://github.com/LBHackney-IT/lbh-base-api/wiki/Integration-Tests
-    public class ExampleTest : IntegrationTests<Startup>
+    public class GetResidentByIdTest : IntegrationTests<Startup>
     {
+        private readonly IFixture _fixture = new Fixture();
 
+        [Test]
+        public async Task GetResidentByIdWillReturnResidentDetailsIfFound()
+        {
+            var expectedResident = SaveResidentsElectorRecordsToTheDatabase();
+            var response = await CallEndpointWithId(expectedResident.Id).ConfigureAwait(true);
+            response.StatusCode.Should().Be(200);
+
+            var data = await ConvertToResponseObject(response).ConfigureAwait(true);
+            data.Should().BeEquivalentTo(expectedResident);
+        }
+
+        [Test]
+        public async Task GetResidentDetailsWillReturn404IfNotFound()
+        {
+            var response = await CallEndpointWithId(7).ConfigureAwait(true);
+            response.StatusCode.Should().Be(404);
+        }
+
+        private async Task<HttpResponseMessage> CallEndpointWithId(int id)
+        {
+            var url = new Uri($"/api/v1/residents/{id}", UriKind.Relative);
+            return await Client.GetAsync(url).ConfigureAwait(true);
+        }
+
+        private static async Task<ResidentResponse> ConvertToResponseObject(HttpResponseMessage response)
+        {
+            var data = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            return JsonConvert.DeserializeObject<ResidentResponse>(data);
+        }
+
+        private ResidentResponse SaveResidentsElectorRecordsToTheDatabase()
+        {
+            var property = _fixture.Build<ElectorsProperty>()
+                .With(e => e.Uprn, _fixture.Create<int>().ToString).Create();
+            ElectoralRegisterContext.Properties.Add(property);
+            ElectoralRegisterContext.SaveChanges();
+
+            var elector = _fixture.Build<Elector>()
+                .Without(e => e.ElectorsProperty)
+                .Without(e => e.ElectorExtension)
+                .With(e => e.PropertyId, property.Id)
+                .Create();
+            ElectoralRegisterContext.Electors.Add(elector);
+            ElectoralRegisterContext.SaveChanges();
+
+            var electorExtension = _fixture.Build<ElectorExtension>()
+                .With(e => e.Id, elector.Id)
+                .Create();
+            ElectoralRegisterContext.ElectorExtensions.Add(electorExtension);
+            ElectoralRegisterContext.SaveChanges();
+
+            var expectedResponse = new ResidentResponse
+            {
+                Id = elector.Id,
+                Email = elector.Email,
+                Nationality = elector.Nationality,
+                Title = elector.Title,
+                Uprn = Convert.ToInt32(property.Uprn),
+                FirstName = elector.FirstName,
+                LastName = elector.LastName,
+                MiddleName = electorExtension.MiddleName,
+                DateOfBirth = electorExtension.DateOfBirth.ToString("yyyy-MM-dd")
+            };
+            return expectedResponse;
+        }
     }
 }

--- a/ElectoralRegisterResidentInformationApi.Tests/V1/Factories/EntityFactoryTest.cs
+++ b/ElectoralRegisterResidentInformationApi.Tests/V1/Factories/EntityFactoryTest.cs
@@ -50,37 +50,21 @@ namespace ElectoralRegisterResidentInformationApi.Tests.V1.Factories
         }
 
         [Test]
-        public void CanMapAnElectorExtensionWithElectorAttachedToResidentDomain()
+        public void CanMapAnElectorWithAttachedElectorExtensionToResidentDomain()
         {
-            var electorExtension = new ElectorExtension
+            var electorExtension = new Elector
             {
                 Id = 83,
-                MiddleName = "John",
-                DateOfBirth = new DateTime(2001, 04, 05),
-                Elector = new Elector
+                ElectorExtension = new ElectorExtension
                 {
                     Id = 77,
-                    Email = "contact-me@my-email.co.uk",
-                    Nationality = "Russian",
-                    Title = "Prof.",
-                    FirstName = "Green",
-                    LastName = "White",
-                    ElectorsProperty = new ElectorsProperty
-                    {
-                        Id = 88,
-                        Uprn = "9842274",
-                    }
+                    MiddleName = "John",
+                    DateOfBirth = new DateTime(2001, 04, 05)
                 }
             };
             var resident = electorExtension.ToDomain();
 
-            resident.Id.Should().Be(77);
-            resident.Email.Should().Be("contact-me@my-email.co.uk");
-            resident.Nationality.Should().Be("Russian");
-            resident.Title.Should().Be("Prof.");
-            resident.FirstName.Should().Be("Green");
-            resident.LastName.Should().Be("White");
-            resident.Uprn.Should().Be(9842274);
+            resident.Id.Should().Be(83);
             resident.MiddleName.Should().Be("John");
             resident.DateOfBirth.Should().Be(new DateTime(2001, 04, 05));
         }

--- a/ElectoralRegisterResidentInformationApi/V1/Controllers/ElectoralRegisterController.cs
+++ b/ElectoralRegisterResidentInformationApi/V1/Controllers/ElectoralRegisterController.cs
@@ -1,4 +1,5 @@
 using ElectoralRegisterResidentInformationApi.V1.Boundary.Response;
+using ElectoralRegisterResidentInformationApi.V1.Domain;
 using ElectoralRegisterResidentInformationApi.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -43,7 +44,14 @@ namespace ElectoralRegisterResidentInformationApi.V1.Controllers
         [Route("{id}")]
         public IActionResult ViewRecord(int id)
         {
-            return Ok(_getResidentByIdUseCase.Execute(id));
+            try
+            {
+                return Ok(_getResidentByIdUseCase.Execute(id));
+            }
+            catch (ResidentNotFoundException)
+            {
+                return NotFound("No record could be found for the provided ID");
+            }
         }
     }
 }

--- a/ElectoralRegisterResidentInformationApi/V1/Domain/Resident.cs
+++ b/ElectoralRegisterResidentInformationApi/V1/Domain/Resident.cs
@@ -9,7 +9,7 @@ namespace ElectoralRegisterResidentInformationApi.V1.Domain
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string MiddleName { get; set; }
-        public DateTime DateOfBirth { get; set; }
+        public DateTime? DateOfBirth { get; set; }
         public string Email { get; set; }
         public string Nationality { get; set; }
         public int? Uprn { get; set; }

--- a/ElectoralRegisterResidentInformationApi/V1/Domain/ResidentNotFoundException.cs
+++ b/ElectoralRegisterResidentInformationApi/V1/Domain/ResidentNotFoundException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace ElectoralRegisterResidentInformationApi.V1.Domain
+{
+    public class ResidentNotFoundException : Exception
+    {
+    }
+}

--- a/ElectoralRegisterResidentInformationApi/V1/Factories/EntityFactory.cs
+++ b/ElectoralRegisterResidentInformationApi/V1/Factories/EntityFactory.cs
@@ -17,15 +17,9 @@ namespace ElectoralRegisterResidentInformationApi.V1.Factories
                 Uprn = elector.ElectorsProperty?.Uprn != null ? Convert.ToInt32(elector.ElectorsProperty?.Uprn) : (int?) null,
                 FirstName = elector.FirstName,
                 LastName = elector.LastName,
+                MiddleName = elector.ElectorExtension?.MiddleName,
+                DateOfBirth = elector.ElectorExtension?.DateOfBirth
             };
-        }
-
-        public static Resident ToDomain(this ElectorExtension electorExtension)
-        {
-            var resident = electorExtension.Elector != null ? electorExtension.Elector.ToDomain() : new Resident();
-            resident.DateOfBirth = electorExtension.DateOfBirth;
-            resident.MiddleName = electorExtension.MiddleName;
-            return resident;
         }
     }
 }

--- a/ElectoralRegisterResidentInformationApi/V1/Factories/ResponseFactory.cs
+++ b/ElectoralRegisterResidentInformationApi/V1/Factories/ResponseFactory.cs
@@ -17,7 +17,7 @@ namespace ElectoralRegisterResidentInformationApi.V1.Factories
                 MiddleName = resident.MiddleName,
                 LastName = resident.LastName,
                 Nationality = resident.Nationality,
-                DateOfBirth = resident.DateOfBirth.ToString("yyyy-MM-dd"),
+                DateOfBirth = resident.DateOfBirth?.ToString("yyyy-MM-dd"),
                 Email = resident.Email,
                 Uprn = resident.Uprn
             };

--- a/ElectoralRegisterResidentInformationApi/V1/Gateways/ElectoralRegisterGateway.cs
+++ b/ElectoralRegisterResidentInformationApi/V1/Gateways/ElectoralRegisterGateway.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
+using System.Linq;
 using ElectoralRegisterResidentInformationApi.V1.Domain;
 using ElectoralRegisterResidentInformationApi.V1.Factories;
 using ElectoralRegisterResidentInformationApi.V1.Infrastructure;
+using Microsoft.EntityFrameworkCore;
 
 namespace ElectoralRegisterResidentInformationApi.V1.Gateways
 {
-    //TODO: Rename to match the data source that is being accessed in the gateway eg. MosaicGateway
     public class ElectoralRegisterGateway : IElectoralRegisterGateway
     {
         private readonly ElectoralRegisterContext _electoralRegisterContext;
@@ -17,9 +18,10 @@ namespace ElectoralRegisterResidentInformationApi.V1.Gateways
 
         public Resident GetEntityById(int id)
         {
-            var result = _electoralRegisterContext.Electors.Find(id);
-
-            return result?.ToDomain();
+            return _electoralRegisterContext.Electors
+                .Include(e => e.ElectorExtension)
+                .Include(e => e.ElectorsProperty)
+                .FirstOrDefault(e => e.Id == id)?.ToDomain();
         }
 
         public List<Resident> GetAll()

--- a/ElectoralRegisterResidentInformationApi/V1/Infrastructure/Elector.cs
+++ b/ElectoralRegisterResidentInformationApi/V1/Infrastructure/Elector.cs
@@ -9,6 +9,9 @@ namespace ElectoralRegisterResidentInformationApi.V1.Infrastructure
         [Column("Id")]
         public int Id { get; set; }
 
+        [ForeignKey("Id")]
+        public ElectorExtension ElectorExtension { get; set; }
+
         [Column("ElectorForename")]
         [MaxLength(50)]
         public string FirstName { get; set; }

--- a/ElectoralRegisterResidentInformationApi/V1/Infrastructure/ElectorExtension.cs
+++ b/ElectoralRegisterResidentInformationApi/V1/Infrastructure/ElectorExtension.cs
@@ -10,17 +10,28 @@ namespace ElectoralRegisterResidentInformationApi.V1.Infrastructure
         [Column("Id")]
         public int Id { get; set; }
 
-        [Column("sysElectorId")]
-        public int ElectorId { get; set; }
-
-        [ForeignKey("ElectorId")]
-        public Elector Elector { get; set; }
-
         [Column("MiddleName")]
         [MaxLength(200)]
         public string MiddleName { get; set; }
 
         [Column("DOB")]
         public DateTime DateOfBirth { get; set; }
+
+        [Column("NINOPassword")]
+        [MaxLength(512)]
+        public string NinoPassword { get; set; }
+
+        [Column("ITRSourceID")]
+        public int ItrSourceId { get; set; }
+
+        [Column("RAG")]
+        [MaxLength(1)]
+        public string Rag { get; set; }
+
+        [Column("DeceasedEvidenceAcknowledgement")]
+        public bool DeceasedEvidenceAcknowledgement { get; set; }
+
+        [Column("UnsubscribeEmail")]
+        public bool UnsubscribeEmail { get; set; }
     }
 }

--- a/ElectoralRegisterResidentInformationApi/V1/UseCase/GetResidentByIdUseCase.cs
+++ b/ElectoralRegisterResidentInformationApi/V1/UseCase/GetResidentByIdUseCase.cs
@@ -1,4 +1,5 @@
 using ElectoralRegisterResidentInformationApi.V1.Boundary.Response;
+using ElectoralRegisterResidentInformationApi.V1.Domain;
 using ElectoralRegisterResidentInformationApi.V1.Factories;
 using ElectoralRegisterResidentInformationApi.V1.Gateways;
 using ElectoralRegisterResidentInformationApi.V1.UseCase.Interfaces;
@@ -7,7 +8,7 @@ namespace ElectoralRegisterResidentInformationApi.V1.UseCase
 {
     public class GetResidentByIdUseCase : IGetResidentByIdUseCase
     {
-        private IElectoralRegisterGateway _gateway;
+        private readonly IElectoralRegisterGateway _gateway;
         public GetResidentByIdUseCase(IElectoralRegisterGateway gateway)
         {
             _gateway = gateway;
@@ -15,7 +16,10 @@ namespace ElectoralRegisterResidentInformationApi.V1.UseCase
 
         public ResidentResponse Execute(int id)
         {
-            return _gateway.GetEntityById(id).ToResponse();
+            var resident = _gateway.GetEntityById(id);
+            if (resident == null) throw new ResidentNotFoundException();
+
+            return resident.ToResponse();
         }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-351

## Describe this PR

### *What is the problem we're trying to solve*

The overall work for this ticket is to add an endpoint that allows you to retrieve a single residents information for a given ID.

### *What changes have we introduced*

This PR adds gateway and use case logic to get a resident's information from the elector register using the elector, elector extension and property tables.
A 404 status code will be returned an elector record can not be found for the given ID.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

- a canary needs to be added in production.
- needs to be tested in staging and production after merging
