### PR TITLE
Rewire the pipeline workflows for decommissioning work. Ensure working pipeline dependency versions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_18.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,21 @@ workflows:
           filters:
              branches:
                only: master
+      - permit-development-terraform-release:
+          type: approval
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: master
       - terraform-init-and-apply-to-staging:
+          requires:
+            - permit-development-terraform-release
+          filters:
+            branches:
+              only: master
+      - permit-staging-serverless-release:
+          type: approval
           requires:
             - assume-role-staging
           filters:
@@ -204,38 +218,41 @@ workflows:
               only: master
       - deploy-to-staging:
           requires:
-            - assume-role-staging
+            - permit-staging-serverless-release
           filters:
             branches:
               only: master
-      - permit-production-terraform-release:
-          type: approval
-          requires:
-            - deploy-to-staging
       - assume-role-production:
           context: api-assume-role-production-context
           requires:
-              - permit-production-terraform-release
+              - deploy-to-staging
+              - terraform-init-and-apply-to-staging
+          filters:
+             branches:
+               only: master
+      - permit-production-terraform-release:
+          type: approval
+          requires:
+            - assume-role-production
           filters:
              branches:
                only: master
       - terraform-init-and-apply-to-production:
           requires:
-            - assume-role-production
+            - permit-production-terraform-release
           filters:
             branches:
               only: master
       - permit-production-release:
           type: approval
           requires:
-            - deploy-to-staging
+            - assume-role-production
           filters:
             branches:
               only: master
       - deploy-to-production:
           requires:
             - permit-production-release
-            - assume-role-production
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
           stage: "production"
 
 workflows:      
-  check-and-deploy-staging-and-production:
+  remove-serverless-and-terraform-resources:
       jobs:
       - assume-role-development:
           context: api-assume-role-development-context
@@ -167,7 +167,7 @@ workflows:
           filters:
              branches:
                only: master
-      - permit-development-terraform-release:
+      - permit-staging-terraform-release:
           type: approval
           requires:
             - assume-role-staging
@@ -176,7 +176,7 @@ workflows:
               only: master
       - terraform-init-and-apply-to-staging:
           requires:
-            - permit-development-terraform-release
+            - permit-staging-terraform-release
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Deploy lambda
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
 executors:
@@ -81,27 +79,6 @@ commands:
             sls deploy --stage <<parameters.stage>> --conceal
 
 jobs:
-  check-code-formatting:
-    executor: docker-dotnet
-    steps:
-      - checkout
-      - run:
-          name: Install dotnet format
-          command: dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - run:
-          name: Run formatter check
-          command: ./dotnet-format-local/dotnet-format --dry-run --check
-  build-and-test:
-    executor: docker-python
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: build
-          command: docker-compose build electoral-register-resident-information-api-test
-      - run:
-          name: Run tests
-          command: docker-compose run electoral-register-resident-information-api-test
   assume-role-development:
     executor: docker-python
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,40 +154,45 @@ jobs:
       - deploy-lambda:
           stage: "production"
 
-workflows:
-  check-and-deploy-development:
-    jobs:
-      - check-code-formatting
-      - build-and-test
-      - assume-role-development:
-          context: api-assume-role-development-context
-          requires:
-            - build-and-test
-          filters:
-            branches:
-              only: development
-      - terraform-init-and-apply-to-development:
-          requires:
-            - assume-role-development
-          filters:
-            branches:
-              only: development
-      - deploy-to-development:
-          requires:
-            - assume-role-development
-          filters:
-            branches:
-              only: development
+workflows:      
   check-and-deploy-staging-and-production:
       jobs:
-      - build-and-test:
+      - assume-role-development:
+          context: api-assume-role-development-context
+          filters:
+            branches:
+              only: master
+      - permit-development-terraform-release:
+          type: approval
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-development:
+          requires:
+            - permit-development-terraform-release
+          filters:
+            branches:
+              only: master
+      - permit-development-serverless-release:
+          type: approval
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              only: master
+      - deploy-to-development:
+          requires:
+            - permit-development-serverless-release
           filters:
             branches:
               only: master
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:
-              - build-and-test
+              - deploy-to-development
+              - terraform-init-and-apply-to-development
           filters:
              branches:
                only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,12 +75,6 @@ commands:
           name: Install serverless CLI
           command: npm i -g serverless
       - run:
-          name: Build lambda
-          command: |
-            cd ./ElectoralRegisterResidentInformationApi/
-            chmod +x ./build.sh
-            ./build.sh
-      - run:
           name: Deploy lambda
           command: |
             cd ./ElectoralRegisterResidentInformationApi/


### PR DESCRIPTION
# What:
 - Upgrade pipeline's node.js to version 18.
 - Cap serverless to major version v3.
 - Remove code formatting and application build & test steps from the workflows and commands.
 - Join the `development` workflow with `staging/production` workflow.
 - Rewire that workflow to have independent terraform and serverless releases.

# Why:
 - Node versions pre v16 have 20s + 60s wait timer during the old node version deprecation message. Current non-deprecated version is v18.
 - Capped serverless due to change in license going from v3 to v4. New changes require having an account with paid license.
 - Joined the `development` workflow to the main workflow to reduce unnecessary PRs during this decommissioning work.
 - Need to have independent TF and SLS releases because some TF resources cannot be decommissioned without removing certain serverless resources first.

# Notes:
 - The pipeline will be failing once merged because of expired SSH key. Will be addressed shortly.