### PR TITLE
Remove the no longer relevant CODEOWNERS file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @LBHMGeorgieva @LBHMKeyworth @LBHSPreston @LBHRShetty


### PR DESCRIPTION
# What:
 - Remove the stale CODEOWNERS file.

# Why:
 - The application database is getting decommissioned with it all its other cloud resources.
 - The repository is going to get re-archived soon after.

# Notes:
 - The pipeline is expected to fail due to expired SSH key.