### PR TITLE
Retire `DevelopmentAPIs` serverless resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,12 @@ commands:
           name: Deploy lambda
           command: |
             cd ./ElectoralRegisterResidentInformationApi/
-            sls deploy --stage <<parameters.stage>> --conceal
+            if [ "<<parameters.stage>>" = "development" ]
+            then
+              sls remove --stage <<parameters.stage>> --verbose
+            else
+              sls deploy --stage <<parameters.stage>> --conceal
+            fi
 
 jobs:
   assume-role-development:


### PR DESCRIPTION
# What:
 - Make the pipeline retire `DevelopmentAPIs` serverless resources.

# Why:
 - The database that was possibly named `electoral-register-mirror-db-db-development` appears to have been decommissioned long time ago. There seems to be no snapshot leftover within this environment.
 - The remaining application stack has no database to connect to and as such should be decommissioned as well, however, this appears to have been skipped at the time, hence the need for this PR.

# Notes:
 - The pipeline shows as failing due renamed VPCs - not an issue.