### PR TITLE
Retire `StagingAPIs` serverless resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./ElectoralRegisterResidentInformationApi/
-            if [ "<<parameters.stage>>" = "environment" ]
+            if [ "<<parameters.stage>>" = "staging" ]
             then
               sls remove --stage <<parameters.stage>> --verbose
             else


### PR DESCRIPTION
# What:
 - Retire `StagingAPIs` serverless resources.

# Why:
 - The `electoral-register-mirror-db-db-staging` database is about to be decommissioned, and so an API that connects to it needs to go as well.
 - Doing serverless resources first to avoid potentials security group conflicts whilst removing the database.

# Notes: 
- The pipeline is expected to fail because of failing TF preview for `staging` and `production` environments. This is because at some point since the config was written, the VPCs were renamed and are no longer accessible via an old name.