### PR TITLE
Retire postgres AWS RDS database on `StagingAPIs` account.

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -11,21 +11,6 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
-data "aws_caller_identity" "current" {}
-
-data "aws_region" "current" {}
-
-locals {
-  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
-
-data "aws_iam_role" "ec2_container_service_role" {
-  name = "ecsServiceRole"
-}
-
-data "aws_iam_role" "ecs_task_execution_role" {
-  name = "ecsTaskExecutionRole"
-}
 
 terraform {
   backend "s3" {
@@ -34,28 +19,4 @@ terraform {
     region  = "eu-west-2"
     key     = "services/electoral-register-information-api/state"
   }
-}
-
-/*    POSTGRES SET UP    */
-
-data "aws_vpc" "staging_vpc" {
-  tags = {
-    Name = "vpc-staging-apis-staging"
-  }
-}
-
-data "aws_subnet_ids" "staging" {
-  vpc_id = data.aws_vpc.staging_vpc.id
-  filter {
-    name   = "tag:Type"
-    values = ["private"]
-  }
-}
-
-data "aws_ssm_parameter" "electoral_register_postgres_db_password" {
-  name = "/electoral-register-api/staging/postgres-password"
-}
-
-data "aws_ssm_parameter" "electoral_register_postgres_username" {
-  name = "/electoral-register-api/staging/postgres-username"
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -59,24 +59,3 @@ data "aws_ssm_parameter" "electoral_register_postgres_db_password" {
 data "aws_ssm_parameter" "electoral_register_postgres_username" {
   name = "/electoral-register-api/staging/postgres-username"
 }
-
-module "postgres_db_staging" {
-  source               = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name     = "staging"
-  vpc_id               = data.aws_vpc.staging_vpc.id
-  db_identifier        = "electoral-register-mirror-db"
-  db_name              = "electoral_register_mirror"
-  db_port              = 5402
-  subnet_ids           = data.aws_subnet_ids.staging.ids
-  db_engine            = "postgres"
-  db_engine_version    = "11.1"
-  db_instance_class    = "db.t2.micro"
-  db_allocated_storage = 20
-  maintenance_window   = "sun:10:00-sun:10:30"
-  db_username          = data.aws_ssm_parameter.electoral_register_postgres_username.value
-  db_password          = data.aws_ssm_parameter.electoral_register_postgres_db_password.value
-  storage_encrypted    = false
-  multi_az             = false //only true if production deployment
-  publicly_accessible  = false
-  project_name         = "platform apis"
-}


### PR DESCRIPTION
# What:
 - Retire the `electoral-register-mirror-db-db-staging` AWS RDS database on `StagingAPIs` account.

# Why:
 - The database hasn't been connected to in over 15 months.
 - It was marked for deletion during CoP.

# Notes:
 - The database snapshot was created under the name of: `electoral-register-mirror-db-db-staging-unused-for-over-15mo-snapshot`.
 - The pipeline shows as failing due to renamed `ProductionAPIs` VPC, so the TF preview `data` lookup fails. Not of consequence right now.

# Screenshots:

| No connections to staging database in over 15 months |
| --- |
| ![image](https://github.com/user-attachments/assets/827c7d6d-8360-49b2-b330-22b97682725b) |