### PR TITLE
Retire ProductionAPIs serverless resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./ElectoralRegisterResidentInformationApi/
-            if [ "<<parameters.stage>>" = "environment" ]
+            if [ "<<parameters.stage>>" = "production" ]
             then
               sls remove --stage <<parameters.stage>> --verbose
             else


### PR DESCRIPTION
# What:
  - Make the pipeline remove the `ProductionAPIs` serverless managed resources.

# Why:
 - The database that the API connects to is about to be decommissioned _(see PR #21 )_.

# Notes:
 - The terraform preview is failing due to renamed `ProductionAPIs` VPC, so the lookup it's trying to do cannot be performed.