### PR TITLE
Retire `ProductionAPIs` terraform managed resources.

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -51,24 +51,3 @@ data "aws_ssm_parameter" "electoral_register_postgres_db_password" {
 data "aws_ssm_parameter" "electoral_register_postgres_username" {
   name = "/electoral-register-api/production/postgres-username"
 }
-
-module "postgres_db_production" {
-  source               = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name     = "production"
-  vpc_id               = data.aws_vpc.production_vpc.id
-  db_identifier        = "electoral-register-mirror-db"
-  db_name              = "electoral_register_mirror"
-  db_port              = 5400
-  subnet_ids           = data.aws_subnet_ids.production.ids
-  db_engine            = "postgres"
-  db_engine_version    = "11.1"
-  db_instance_class    = "db.t2.micro"
-  db_allocated_storage = 20
-  maintenance_window   = "sun:10:00-sun:10:30"
-  db_username          = data.aws_ssm_parameter.electoral_register_postgres_username.value
-  db_password          = data.aws_ssm_parameter.electoral_register_postgres_db_password.value
-  storage_encrypted    = false
-  multi_az             = true //only true if production deployment
-  publicly_accessible  = false
-  project_name         = "platform apis"
-}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -11,13 +11,6 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
-data "aws_caller_identity" "current" {}
-
-data "aws_region" "current" {}
-
-locals {
-  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
 
 terraform {
   backend "s3" {
@@ -26,28 +19,4 @@ terraform {
     region  = "eu-west-2"
     key     = "services/electoral-register-information-api/state"
   }
-}
-
-/*    POSTGRES SET UP    */
-
-data "aws_vpc" "production_vpc" {
-  tags = {
-    Name = "vpc-production-apis-production"
-  }
-}
-
-data "aws_subnet_ids" "production" {
-  vpc_id = data.aws_vpc.production_vpc.id
-  filter {
-    name   = "tag:Type"
-    values = ["private"]
-  }
-}
-
-data "aws_ssm_parameter" "electoral_register_postgres_db_password" {
-  name = "/electoral-register-api/production/postgres-password"
-}
-
-data "aws_ssm_parameter" "electoral_register_postgres_username" {
-  name = "/electoral-register-api/production/postgres-username"
 }


### PR DESCRIPTION
# What:
 - Retire `ProductionAPIs` Terraform managed resources.
 - This retires the `electoral-register-mirror-db-db-production` database.

# Why:
 - The database hasn't been in use in over 15 months, and was marked for deletion.

# Notes:
 - The database snapshot was taken under the name of: `electoral-register-mirror-db-db-production-not-used-in-15mo-snapshot`.

# Screenshots:

| No connections to production for over 15 months | Database production snapshot |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/e0ee478e-59b5-4c0c-9300-57c7013589c5) | ![image](https://github.com/user-attachments/assets/9e3f0dc8-0ed7-48a5-b5f5-ce49c65d31e0) |